### PR TITLE
Update: Adding Chainguard distroless image as base

### DIFF
--- a/dockerfiles/agent/container/Dockerfile
+++ b/dockerfiles/agent/container/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.19 AS builder
+FROM cgr.dev/chainguard/go:1.20 AS base
 WORKDIR /
 COPY ./ ./
 
-RUN go mod download
-RUN CGO_ENABLED=0 go build -o ./build/agent agent/container/main.go
+RUN go mod download \
+    && CGO_ENABLED=0 go build -o ./build/agent agent/container/main.go
 
 FROM scratch
-COPY --from=builder ./build/agent agent
+COPY --from=base ./build/agent agent
 
 USER 65532:65532
-ENTRYPOINT ["/agent"]
+ENTRYPOINT [ "/agent" ]


### PR DESCRIPTION
This PR updates the base image for the agent Dockerfile with Chainguard's distroless image.
Once this pr is reviewed and merged, all the images in the repo will be updated accordingly with Chainguard's images following best practices for building images.

Request review of the same

